### PR TITLE
Chore/commitlint-hook

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,12 @@ FROM mcr.microsoft.com/devcontainers/python:3.12
 # Switch to root to install global tools
 USER root
 
+# install nodejs (v18.x) and globally install commitlint
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get update && \
+    apt-get install -y nodejs && \
+    npm install -g @commitlint/cli @commitlint/config-conventional
+
 # Install uv globally
 RUN pip install --upgrade pip \
     && pip install uv

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
         "dockerfile": "Dockerfile",
         "context": ".."
     },
-    "postCreateCommand": ". .venv/bin/activate && pre-commit install",
+    "postCreateCommand": ". .venv/bin/activate && pre-commit install --hook-type pre-commit --hook-type commit-msg",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,8 @@ repos:
         entry: pytest --collect-only tests/
         language: system
         types: [python]
+      - id: commitlint
+        name: commitlint (Conventional Commits)
+        entry: commitlint --edit "$1"
+        language: system
+        stages: [commit-msg]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,8 +25,10 @@ repos:
         entry: pytest --collect-only tests/
         language: system
         types: [python]
+
       - id: commitlint
         name: commitlint (Conventional Commits)
-        entry: commitlint --edit "$1"
+        entry: commitlint
         language: system
         stages: [commit-msg]
+        args: ["--edit"]

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional']
+};


### PR DESCRIPTION
Add Commitlint Hook for Conventional Commits
Summary
This PR introduces a Commitlint hook to enforce Conventional Commits in the project. The hook ensures that all commit messages follow the Conventional Commits specification, improving commit message consistency and enabling better automation for semantic versioning and changelog generation.

Changes
Updated .pre-commit-config.yaml to include a commitlint hook:
Configured to run during the commit-msg stage.
Uses the @commitlint/config-conventional ruleset.
Added commitlint.config.js to define the Commitlint configuration.
Benefits
Enforces a standardized commit message format.
Improves the automation of semantic-release workflows.
Enhances collaboration by making commit history easier to understand.